### PR TITLE
scripts: add script to check if index.html is up-to-date

### DIFF
--- a/scripts/check-index.sh
+++ b/scripts/check-index.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Get the past 4 Kubernetes releases not counting the latest available
+# example: 1.19 (latest), 4 last releases: 1.18, 1.17, 1.16, 1.15
+LASTRELEASES=4
+COUNTER=0
+RELEASES=()
+INDEXFILE=dist/index.html
+EXITSTATUS=0
+
+LATEST=$(curl -Ls https://dl.k8s.io/release/stable.txt)
+LATESTMAJOR=`echo $LATEST | cut -dv -d. -f1`
+LATESTMINOR=`echo $LATEST | cut -d. -f2`
+RELEASES+=($LATEST)
+
+function check_index {
+  status=()
+  for tag in "${RELEASES[@]}"; do
+    result=`grep -Rq "$tag" "$INDEXFILE" >/dev/null; echo $?`
+    if [ $result -eq 1 ]; then
+      echo "$tag not found in the index.html, please update the index.html file"
+      status+=1
+    fi
+  done
+
+  if [[ " ${status[@]} " =~ 1 ]]; then
+    return 1
+  fi
+}
+
+function get_kubernetes_releases {
+  echo "Getting Kubernetes releases"
+  while [  $COUNTER -lt $LASTRELEASES ]; do
+    let "LATESTMINOR-=1"
+    TEMP=$(curl -Ls https://dl.k8s.io/release/stable-${LATESTMAJOR:1}.$LATESTMINOR.txt)
+    RELEASES+=("$TEMP")
+    let COUNTER+=1
+  done
+  echo "Will validate the index.html using the following releases: ${RELEASES[@]}"
+}
+
+get_kubernetes_releases || exit 1
+check_index || exit 1


### PR DESCRIPTION
Had some conversation with @saschagrunert to add a PROW job (per issue: https://github.com/kubernetes-sigs/downloadkubernetes/issues/12) and one of the possible pre-submit jobs is to validate if the content is up-to-date.

So we thought a simple bash (honk) script should be enough, for now, to check if that contains the last k8s releases.

If we decide to merge this, then the next step is to set up the Prow job to use that.

/cc @saschagrunert @justaugustus 

open to feedback and also it is okay to close if this makes no sense