### PR TITLE
Add checksum link

### DIFF
--- a/cmd/update-index/data/index.html.template
+++ b/cmd/update-index/data/index.html.template
@@ -99,6 +99,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://{{.Link}}">{{.Link}}</a>
+                            (<a class="copy" href="https://{{.Link}}.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>

--- a/dist/index.html
+++ b/dist/index.html
@@ -102,6 +102,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/darwin/amd64/kubectl">dl.k8s.io/v1.20.5/bin/darwin/amd64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/darwin/amd64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -120,6 +121,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/386/kubectl">dl.k8s.io/v1.20.5/bin/linux/386/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/386/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -138,6 +140,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/apiextensions-apiserver">dl.k8s.io/v1.20.5/bin/linux/amd64/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -156,6 +159,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kube-aggregator">dl.k8s.io/v1.20.5/bin/linux/amd64/kube-aggregator</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kube-aggregator.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -174,6 +178,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kube-apiserver">dl.k8s.io/v1.20.5/bin/linux/amd64/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -192,6 +197,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kube-controller-manager">dl.k8s.io/v1.20.5/bin/linux/amd64/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -210,6 +216,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kube-proxy">dl.k8s.io/v1.20.5/bin/linux/amd64/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -228,6 +235,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kube-scheduler">dl.k8s.io/v1.20.5/bin/linux/amd64/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -246,6 +254,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kubeadm">dl.k8s.io/v1.20.5/bin/linux/amd64/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -264,6 +273,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kubectl">dl.k8s.io/v1.20.5/bin/linux/amd64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -282,6 +292,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kubelet">dl.k8s.io/v1.20.5/bin/linux/amd64/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -300,6 +311,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/mounter">dl.k8s.io/v1.20.5/bin/linux/amd64/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/amd64/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -318,6 +330,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/apiextensions-apiserver">dl.k8s.io/v1.20.5/bin/linux/arm/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -336,6 +349,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kube-aggregator">dl.k8s.io/v1.20.5/bin/linux/arm/kube-aggregator</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kube-aggregator.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -354,6 +368,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kube-apiserver">dl.k8s.io/v1.20.5/bin/linux/arm/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -372,6 +387,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kube-controller-manager">dl.k8s.io/v1.20.5/bin/linux/arm/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -390,6 +406,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kube-proxy">dl.k8s.io/v1.20.5/bin/linux/arm/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -408,6 +425,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kube-scheduler">dl.k8s.io/v1.20.5/bin/linux/arm/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -426,6 +444,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kubeadm">dl.k8s.io/v1.20.5/bin/linux/arm/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -444,6 +463,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kubectl">dl.k8s.io/v1.20.5/bin/linux/arm/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -462,6 +482,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kubelet">dl.k8s.io/v1.20.5/bin/linux/arm/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -480,6 +501,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/mounter">dl.k8s.io/v1.20.5/bin/linux/arm/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -498,6 +520,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/apiextensions-apiserver">dl.k8s.io/v1.20.5/bin/linux/arm64/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -516,6 +539,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kube-aggregator">dl.k8s.io/v1.20.5/bin/linux/arm64/kube-aggregator</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kube-aggregator.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -534,6 +558,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kube-apiserver">dl.k8s.io/v1.20.5/bin/linux/arm64/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -552,6 +577,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kube-controller-manager">dl.k8s.io/v1.20.5/bin/linux/arm64/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -570,6 +596,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kube-proxy">dl.k8s.io/v1.20.5/bin/linux/arm64/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -588,6 +615,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kube-scheduler">dl.k8s.io/v1.20.5/bin/linux/arm64/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -606,6 +634,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kubeadm">dl.k8s.io/v1.20.5/bin/linux/arm64/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -624,6 +653,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kubectl">dl.k8s.io/v1.20.5/bin/linux/arm64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -642,6 +672,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kubelet">dl.k8s.io/v1.20.5/bin/linux/arm64/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -660,6 +691,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/mounter">dl.k8s.io/v1.20.5/bin/linux/arm64/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/arm64/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -678,6 +710,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/apiextensions-apiserver">dl.k8s.io/v1.20.5/bin/linux/ppc64le/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -696,6 +729,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-aggregator">dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-aggregator</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-aggregator.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -714,6 +748,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-apiserver">dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -732,6 +767,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-controller-manager">dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -750,6 +786,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-proxy">dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -768,6 +805,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-scheduler">dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -786,6 +824,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kubeadm">dl.k8s.io/v1.20.5/bin/linux/ppc64le/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -804,6 +843,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kubectl">dl.k8s.io/v1.20.5/bin/linux/ppc64le/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -822,6 +862,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kubelet">dl.k8s.io/v1.20.5/bin/linux/ppc64le/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -840,6 +881,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/mounter">dl.k8s.io/v1.20.5/bin/linux/ppc64le/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/ppc64le/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -858,6 +900,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/apiextensions-apiserver">dl.k8s.io/v1.20.5/bin/linux/s390x/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -876,6 +919,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kube-aggregator">dl.k8s.io/v1.20.5/bin/linux/s390x/kube-aggregator</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kube-aggregator.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -894,6 +938,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kube-apiserver">dl.k8s.io/v1.20.5/bin/linux/s390x/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -912,6 +957,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kube-controller-manager">dl.k8s.io/v1.20.5/bin/linux/s390x/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -930,6 +976,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kube-proxy">dl.k8s.io/v1.20.5/bin/linux/s390x/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -948,6 +995,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kube-scheduler">dl.k8s.io/v1.20.5/bin/linux/s390x/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -966,6 +1014,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kubeadm">dl.k8s.io/v1.20.5/bin/linux/s390x/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -984,6 +1033,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kubectl">dl.k8s.io/v1.20.5/bin/linux/s390x/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1002,6 +1052,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kubelet">dl.k8s.io/v1.20.5/bin/linux/s390x/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1020,6 +1071,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/mounter">dl.k8s.io/v1.20.5/bin/linux/s390x/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/linux/s390x/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1038,6 +1090,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/windows/386/kubectl.exe">dl.k8s.io/v1.20.5/bin/windows/386/kubectl.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/windows/386/kubectl.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1056,6 +1109,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/windows/amd64/kube-proxy.exe">dl.k8s.io/v1.20.5/bin/windows/amd64/kube-proxy.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/windows/amd64/kube-proxy.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1074,6 +1128,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/windows/amd64/kubeadm.exe">dl.k8s.io/v1.20.5/bin/windows/amd64/kubeadm.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/windows/amd64/kubeadm.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1092,6 +1147,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/windows/amd64/kubectl.exe">dl.k8s.io/v1.20.5/bin/windows/amd64/kubectl.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/windows/amd64/kubectl.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1110,6 +1166,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.20.5/bin/windows/amd64/kubelet.exe">dl.k8s.io/v1.20.5/bin/windows/amd64/kubelet.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.20.5/bin/windows/amd64/kubelet.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1128,6 +1185,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/darwin/amd64/kubectl">dl.k8s.io/v1.19.9/bin/darwin/amd64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/darwin/amd64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1146,6 +1204,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/386/kubectl">dl.k8s.io/v1.19.9/bin/linux/386/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/386/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1164,6 +1223,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/apiextensions-apiserver">dl.k8s.io/v1.19.9/bin/linux/amd64/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1182,6 +1242,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kube-aggregator">dl.k8s.io/v1.19.9/bin/linux/amd64/kube-aggregator</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kube-aggregator.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1200,6 +1261,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kube-apiserver">dl.k8s.io/v1.19.9/bin/linux/amd64/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1218,6 +1280,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kube-controller-manager">dl.k8s.io/v1.19.9/bin/linux/amd64/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1236,6 +1299,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kube-proxy">dl.k8s.io/v1.19.9/bin/linux/amd64/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1254,6 +1318,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kube-scheduler">dl.k8s.io/v1.19.9/bin/linux/amd64/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1272,6 +1337,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kubeadm">dl.k8s.io/v1.19.9/bin/linux/amd64/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1290,6 +1356,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kubectl">dl.k8s.io/v1.19.9/bin/linux/amd64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1308,6 +1375,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kubelet">dl.k8s.io/v1.19.9/bin/linux/amd64/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1326,6 +1394,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/mounter">dl.k8s.io/v1.19.9/bin/linux/amd64/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/amd64/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1344,6 +1413,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/apiextensions-apiserver">dl.k8s.io/v1.19.9/bin/linux/arm/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1362,6 +1432,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kube-aggregator">dl.k8s.io/v1.19.9/bin/linux/arm/kube-aggregator</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kube-aggregator.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1380,6 +1451,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kube-apiserver">dl.k8s.io/v1.19.9/bin/linux/arm/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1398,6 +1470,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kube-controller-manager">dl.k8s.io/v1.19.9/bin/linux/arm/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1416,6 +1489,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kube-proxy">dl.k8s.io/v1.19.9/bin/linux/arm/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1434,6 +1508,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kube-scheduler">dl.k8s.io/v1.19.9/bin/linux/arm/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1452,6 +1527,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kubeadm">dl.k8s.io/v1.19.9/bin/linux/arm/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1470,6 +1546,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kubectl">dl.k8s.io/v1.19.9/bin/linux/arm/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1488,6 +1565,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kubelet">dl.k8s.io/v1.19.9/bin/linux/arm/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1506,6 +1584,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/mounter">dl.k8s.io/v1.19.9/bin/linux/arm/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1524,6 +1603,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/apiextensions-apiserver">dl.k8s.io/v1.19.9/bin/linux/arm64/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1542,6 +1622,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kube-aggregator">dl.k8s.io/v1.19.9/bin/linux/arm64/kube-aggregator</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kube-aggregator.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1560,6 +1641,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kube-apiserver">dl.k8s.io/v1.19.9/bin/linux/arm64/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1578,6 +1660,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kube-controller-manager">dl.k8s.io/v1.19.9/bin/linux/arm64/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1596,6 +1679,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kube-proxy">dl.k8s.io/v1.19.9/bin/linux/arm64/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1614,6 +1698,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kube-scheduler">dl.k8s.io/v1.19.9/bin/linux/arm64/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1632,6 +1717,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kubeadm">dl.k8s.io/v1.19.9/bin/linux/arm64/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1650,6 +1736,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kubectl">dl.k8s.io/v1.19.9/bin/linux/arm64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1668,6 +1755,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kubelet">dl.k8s.io/v1.19.9/bin/linux/arm64/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1686,6 +1774,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/mounter">dl.k8s.io/v1.19.9/bin/linux/arm64/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/arm64/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1704,6 +1793,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/apiextensions-apiserver">dl.k8s.io/v1.19.9/bin/linux/ppc64le/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1722,6 +1812,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-aggregator">dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-aggregator</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-aggregator.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1740,6 +1831,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-apiserver">dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1758,6 +1850,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-controller-manager">dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1776,6 +1869,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-proxy">dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1794,6 +1888,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-scheduler">dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1812,6 +1907,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kubeadm">dl.k8s.io/v1.19.9/bin/linux/ppc64le/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1830,6 +1926,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kubectl">dl.k8s.io/v1.19.9/bin/linux/ppc64le/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1848,6 +1945,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kubelet">dl.k8s.io/v1.19.9/bin/linux/ppc64le/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1866,6 +1964,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/mounter">dl.k8s.io/v1.19.9/bin/linux/ppc64le/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/ppc64le/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1884,6 +1983,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/apiextensions-apiserver">dl.k8s.io/v1.19.9/bin/linux/s390x/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1902,6 +2002,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kube-aggregator">dl.k8s.io/v1.19.9/bin/linux/s390x/kube-aggregator</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kube-aggregator.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1920,6 +2021,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kube-apiserver">dl.k8s.io/v1.19.9/bin/linux/s390x/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1938,6 +2040,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kube-controller-manager">dl.k8s.io/v1.19.9/bin/linux/s390x/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1956,6 +2059,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kube-proxy">dl.k8s.io/v1.19.9/bin/linux/s390x/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1974,6 +2078,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kube-scheduler">dl.k8s.io/v1.19.9/bin/linux/s390x/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -1992,6 +2097,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kubeadm">dl.k8s.io/v1.19.9/bin/linux/s390x/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2010,6 +2116,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kubectl">dl.k8s.io/v1.19.9/bin/linux/s390x/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2028,6 +2135,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kubelet">dl.k8s.io/v1.19.9/bin/linux/s390x/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2046,6 +2154,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/mounter">dl.k8s.io/v1.19.9/bin/linux/s390x/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/linux/s390x/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2064,6 +2173,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/windows/386/kubectl.exe">dl.k8s.io/v1.19.9/bin/windows/386/kubectl.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/windows/386/kubectl.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2082,6 +2192,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/windows/amd64/kube-proxy.exe">dl.k8s.io/v1.19.9/bin/windows/amd64/kube-proxy.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/windows/amd64/kube-proxy.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2100,6 +2211,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/windows/amd64/kubeadm.exe">dl.k8s.io/v1.19.9/bin/windows/amd64/kubeadm.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/windows/amd64/kubeadm.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2118,6 +2230,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/windows/amd64/kubectl.exe">dl.k8s.io/v1.19.9/bin/windows/amd64/kubectl.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/windows/amd64/kubectl.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2136,6 +2249,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.19.9/bin/windows/amd64/kubelet.exe">dl.k8s.io/v1.19.9/bin/windows/amd64/kubelet.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.19.9/bin/windows/amd64/kubelet.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2154,6 +2268,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/darwin/386/kubectl">dl.k8s.io/v1.18.17/bin/darwin/386/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/darwin/386/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2172,6 +2287,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/darwin/amd64/kubectl">dl.k8s.io/v1.18.17/bin/darwin/amd64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/darwin/amd64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2190,6 +2306,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/386/kubectl">dl.k8s.io/v1.18.17/bin/linux/386/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/386/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2208,6 +2325,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/apiextensions-apiserver">dl.k8s.io/v1.18.17/bin/linux/amd64/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2226,6 +2344,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kube-apiserver">dl.k8s.io/v1.18.17/bin/linux/amd64/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2244,6 +2363,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kube-controller-manager">dl.k8s.io/v1.18.17/bin/linux/amd64/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2262,6 +2382,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kube-proxy">dl.k8s.io/v1.18.17/bin/linux/amd64/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2280,6 +2401,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kube-scheduler">dl.k8s.io/v1.18.17/bin/linux/amd64/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2298,6 +2420,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kubeadm">dl.k8s.io/v1.18.17/bin/linux/amd64/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2316,6 +2439,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kubectl">dl.k8s.io/v1.18.17/bin/linux/amd64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2334,6 +2458,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kubelet">dl.k8s.io/v1.18.17/bin/linux/amd64/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2352,6 +2477,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/mounter">dl.k8s.io/v1.18.17/bin/linux/amd64/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/amd64/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2370,6 +2496,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/apiextensions-apiserver">dl.k8s.io/v1.18.17/bin/linux/arm/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2388,6 +2515,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kube-apiserver">dl.k8s.io/v1.18.17/bin/linux/arm/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2406,6 +2534,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kube-controller-manager">dl.k8s.io/v1.18.17/bin/linux/arm/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2424,6 +2553,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kube-proxy">dl.k8s.io/v1.18.17/bin/linux/arm/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2442,6 +2572,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kube-scheduler">dl.k8s.io/v1.18.17/bin/linux/arm/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2460,6 +2591,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kubeadm">dl.k8s.io/v1.18.17/bin/linux/arm/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2478,6 +2610,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kubectl">dl.k8s.io/v1.18.17/bin/linux/arm/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2496,6 +2629,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kubelet">dl.k8s.io/v1.18.17/bin/linux/arm/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2514,6 +2648,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/mounter">dl.k8s.io/v1.18.17/bin/linux/arm/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2532,6 +2667,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/apiextensions-apiserver">dl.k8s.io/v1.18.17/bin/linux/arm64/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2550,6 +2686,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kube-apiserver">dl.k8s.io/v1.18.17/bin/linux/arm64/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2568,6 +2705,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kube-controller-manager">dl.k8s.io/v1.18.17/bin/linux/arm64/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2586,6 +2724,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kube-proxy">dl.k8s.io/v1.18.17/bin/linux/arm64/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2604,6 +2743,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kube-scheduler">dl.k8s.io/v1.18.17/bin/linux/arm64/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2622,6 +2762,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kubeadm">dl.k8s.io/v1.18.17/bin/linux/arm64/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2640,6 +2781,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kubectl">dl.k8s.io/v1.18.17/bin/linux/arm64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2658,6 +2800,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kubelet">dl.k8s.io/v1.18.17/bin/linux/arm64/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2676,6 +2819,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/mounter">dl.k8s.io/v1.18.17/bin/linux/arm64/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/arm64/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2694,6 +2838,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/apiextensions-apiserver">dl.k8s.io/v1.18.17/bin/linux/ppc64le/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2712,6 +2857,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-apiserver">dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2730,6 +2876,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-controller-manager">dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2748,6 +2895,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-proxy">dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2766,6 +2914,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-scheduler">dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2784,6 +2933,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kubeadm">dl.k8s.io/v1.18.17/bin/linux/ppc64le/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2802,6 +2952,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kubectl">dl.k8s.io/v1.18.17/bin/linux/ppc64le/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2820,6 +2971,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kubelet">dl.k8s.io/v1.18.17/bin/linux/ppc64le/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2838,6 +2990,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/mounter">dl.k8s.io/v1.18.17/bin/linux/ppc64le/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/ppc64le/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2856,6 +3009,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/apiextensions-apiserver">dl.k8s.io/v1.18.17/bin/linux/s390x/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2874,6 +3028,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kube-apiserver">dl.k8s.io/v1.18.17/bin/linux/s390x/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2892,6 +3047,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kube-controller-manager">dl.k8s.io/v1.18.17/bin/linux/s390x/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2910,6 +3066,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kube-proxy">dl.k8s.io/v1.18.17/bin/linux/s390x/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2928,6 +3085,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kube-scheduler">dl.k8s.io/v1.18.17/bin/linux/s390x/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2946,6 +3104,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kubeadm">dl.k8s.io/v1.18.17/bin/linux/s390x/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2964,6 +3123,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kubectl">dl.k8s.io/v1.18.17/bin/linux/s390x/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -2982,6 +3142,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kubelet">dl.k8s.io/v1.18.17/bin/linux/s390x/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3000,6 +3161,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/mounter">dl.k8s.io/v1.18.17/bin/linux/s390x/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/linux/s390x/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3018,6 +3180,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/windows/386/kubectl.exe">dl.k8s.io/v1.18.17/bin/windows/386/kubectl.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/windows/386/kubectl.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3036,6 +3199,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/windows/amd64/kube-proxy.exe">dl.k8s.io/v1.18.17/bin/windows/amd64/kube-proxy.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/windows/amd64/kube-proxy.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3054,6 +3218,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/windows/amd64/kubeadm.exe">dl.k8s.io/v1.18.17/bin/windows/amd64/kubeadm.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/windows/amd64/kubeadm.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3072,6 +3237,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/windows/amd64/kubectl.exe">dl.k8s.io/v1.18.17/bin/windows/amd64/kubectl.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/windows/amd64/kubectl.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3090,6 +3256,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.18.17/bin/windows/amd64/kubelet.exe">dl.k8s.io/v1.18.17/bin/windows/amd64/kubelet.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.18.17/bin/windows/amd64/kubelet.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3108,6 +3275,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/darwin/386/kubectl">dl.k8s.io/v1.17.17/bin/darwin/386/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/darwin/386/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3126,6 +3294,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/darwin/amd64/kubectl">dl.k8s.io/v1.17.17/bin/darwin/amd64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/darwin/amd64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3144,6 +3313,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/386/kubectl">dl.k8s.io/v1.17.17/bin/linux/386/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/386/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3162,6 +3332,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/apiextensions-apiserver">dl.k8s.io/v1.17.17/bin/linux/amd64/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3180,6 +3351,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kube-apiserver">dl.k8s.io/v1.17.17/bin/linux/amd64/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3198,6 +3370,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kube-controller-manager">dl.k8s.io/v1.17.17/bin/linux/amd64/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3216,6 +3389,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kube-proxy">dl.k8s.io/v1.17.17/bin/linux/amd64/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3234,6 +3408,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kube-scheduler">dl.k8s.io/v1.17.17/bin/linux/amd64/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3252,6 +3427,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kubeadm">dl.k8s.io/v1.17.17/bin/linux/amd64/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3270,6 +3446,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kubectl">dl.k8s.io/v1.17.17/bin/linux/amd64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3288,6 +3465,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kubelet">dl.k8s.io/v1.17.17/bin/linux/amd64/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3306,6 +3484,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/mounter">dl.k8s.io/v1.17.17/bin/linux/amd64/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/amd64/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3324,6 +3503,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/apiextensions-apiserver">dl.k8s.io/v1.17.17/bin/linux/arm/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3342,6 +3522,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kube-apiserver">dl.k8s.io/v1.17.17/bin/linux/arm/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3360,6 +3541,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kube-controller-manager">dl.k8s.io/v1.17.17/bin/linux/arm/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3378,6 +3560,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kube-proxy">dl.k8s.io/v1.17.17/bin/linux/arm/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3396,6 +3579,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kube-scheduler">dl.k8s.io/v1.17.17/bin/linux/arm/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3414,6 +3598,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kubeadm">dl.k8s.io/v1.17.17/bin/linux/arm/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3432,6 +3617,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kubectl">dl.k8s.io/v1.17.17/bin/linux/arm/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3450,6 +3636,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kubelet">dl.k8s.io/v1.17.17/bin/linux/arm/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3468,6 +3655,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/mounter">dl.k8s.io/v1.17.17/bin/linux/arm/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3486,6 +3674,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/apiextensions-apiserver">dl.k8s.io/v1.17.17/bin/linux/arm64/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3504,6 +3693,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kube-apiserver">dl.k8s.io/v1.17.17/bin/linux/arm64/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3522,6 +3712,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kube-controller-manager">dl.k8s.io/v1.17.17/bin/linux/arm64/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3540,6 +3731,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kube-proxy">dl.k8s.io/v1.17.17/bin/linux/arm64/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3558,6 +3750,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kube-scheduler">dl.k8s.io/v1.17.17/bin/linux/arm64/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3576,6 +3769,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kubeadm">dl.k8s.io/v1.17.17/bin/linux/arm64/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3594,6 +3788,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kubectl">dl.k8s.io/v1.17.17/bin/linux/arm64/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3612,6 +3807,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kubelet">dl.k8s.io/v1.17.17/bin/linux/arm64/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3630,6 +3826,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/mounter">dl.k8s.io/v1.17.17/bin/linux/arm64/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/arm64/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3648,6 +3845,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/apiextensions-apiserver">dl.k8s.io/v1.17.17/bin/linux/ppc64le/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3666,6 +3864,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-apiserver">dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3684,6 +3883,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-controller-manager">dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3702,6 +3902,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-proxy">dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3720,6 +3921,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-scheduler">dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3738,6 +3940,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kubeadm">dl.k8s.io/v1.17.17/bin/linux/ppc64le/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3756,6 +3959,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kubectl">dl.k8s.io/v1.17.17/bin/linux/ppc64le/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3774,6 +3978,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kubelet">dl.k8s.io/v1.17.17/bin/linux/ppc64le/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3792,6 +3997,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/mounter">dl.k8s.io/v1.17.17/bin/linux/ppc64le/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/ppc64le/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3810,6 +4016,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/apiextensions-apiserver">dl.k8s.io/v1.17.17/bin/linux/s390x/apiextensions-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/apiextensions-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3828,6 +4035,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kube-apiserver">dl.k8s.io/v1.17.17/bin/linux/s390x/kube-apiserver</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kube-apiserver.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3846,6 +4054,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kube-controller-manager">dl.k8s.io/v1.17.17/bin/linux/s390x/kube-controller-manager</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kube-controller-manager.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3864,6 +4073,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kube-proxy">dl.k8s.io/v1.17.17/bin/linux/s390x/kube-proxy</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kube-proxy.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3882,6 +4092,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kube-scheduler">dl.k8s.io/v1.17.17/bin/linux/s390x/kube-scheduler</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kube-scheduler.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3900,6 +4111,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kubeadm">dl.k8s.io/v1.17.17/bin/linux/s390x/kubeadm</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kubeadm.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3918,6 +4130,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kubectl">dl.k8s.io/v1.17.17/bin/linux/s390x/kubectl</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kubectl.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3936,6 +4149,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kubelet">dl.k8s.io/v1.17.17/bin/linux/s390x/kubelet</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/kubelet.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3954,6 +4168,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/mounter">dl.k8s.io/v1.17.17/bin/linux/s390x/mounter</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/linux/s390x/mounter.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3972,6 +4187,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/windows/386/kubectl.exe">dl.k8s.io/v1.17.17/bin/windows/386/kubectl.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/windows/386/kubectl.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -3990,6 +4206,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/windows/amd64/kube-proxy.exe">dl.k8s.io/v1.17.17/bin/windows/amd64/kube-proxy.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/windows/amd64/kube-proxy.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -4008,6 +4225,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/windows/amd64/kubeadm.exe">dl.k8s.io/v1.17.17/bin/windows/amd64/kubeadm.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/windows/amd64/kubeadm.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -4026,6 +4244,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/windows/amd64/kubectl.exe">dl.k8s.io/v1.17.17/bin/windows/amd64/kubectl.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/windows/amd64/kubectl.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>
@@ -4044,6 +4263,7 @@
                         </span>
                         <span title="copy to clipboard">
                             <a class="copy" href="https://dl.k8s.io/v1.17.17/bin/windows/amd64/kubelet.exe">dl.k8s.io/v1.17.17/bin/windows/amd64/kubelet.exe</a>
+                            (<a class="copy" href="https://dl.k8s.io/v1.17.17/bin/windows/amd64/kubelet.exe.sha256">checksum</a>)
                         </span>
                     </td>
                 </tr>


### PR DESCRIPTION
Add checksum link for the binaries.

![image](https://user-images.githubusercontent.com/372575/95104409-cc5ee700-0703-11eb-9c2f-d3ac95a2fc4a.png)

Fixes #8

Note to reviewers: In the process I've updated `dist/index.html` too which updated Kubernetes versions (`v1.19.1 -> v1.19.2`, `v1.18.8 -> v1.18.9`, `v1.17.11 -> v1.17.12`). For visibility I can open its own standalone PR and then rebase this on that.