### PR TITLE
fix check result and status array in check-index script

### DIFF
--- a/scripts/check-index.sh
+++ b/scripts/check-index.sh
@@ -33,10 +33,10 @@ RELEASES+=("$LATEST")
 function check_index {
   status=()
   for tag in "${RELEASES[@]}"; do
-    result=$(grep -Rq "$tag" "$INDEXFILE" >/dev/null; echo $?)
-    if [ "$result" -eq 1 ]; then
+    result=$(grep "$tag" "$INDEXFILE" >/dev/null; echo $?)
+    if [ "$result" -ge 1 ]; then
       echo "$tag not found in the index.html, please update the index.html file"
-      (( status++ ))
+      status[${#status[@]}]=$result
     fi
   done
 
@@ -46,7 +46,7 @@ function check_index {
       exit 1
     fi
   done
-
+  echo "$INDEXFILE is up-to-date"
 }
 
 function get_kubernetes_releases {


### PR DESCRIPTION
- the `-R` was unclear to me as well because we don't check other files just one. dropped this
- also followed the very good explanation from Redbeard and update the script properly, please let me know if that is good

did some tests and now it is reporting the correct issues

Fixes: https://github.com/kubernetes-sigs/downloadkubernetes/issues/33

/assign @saschagrunert @puerco @Verolop @xmudrii @justaugustus 