### PR TITLE
fix: add footer with kubernetes resources

### DIFF
--- a/cmd/update-index/data/index.html.template
+++ b/cmd/update-index/data/index.html.template
@@ -107,6 +107,69 @@
             </tbody>
         </table>
     </section>
+    <footer class="footer has-background-primary">
+        <div class="columns">
+            <div class="column is-3 is-flex is-justify-content-center">
+                <ul class="is-inline is-marginless">
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="User mailing list" aria-label="User mailing list">
+                        <a class="has-text-white" target="_blank" href="https://discuss.kubernetes.io">
+                            <i class="fas fa-envelope"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Twitter" aria-label="Twitter">
+                        <a class="has-text-white" target="_blank" href="https://twitter.com/kubernetesio">
+                            <i class="fab fa-twitter"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Calendar" aria-label="Calendar">
+                        <a class="has-text-white" target="_blank" href="https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io">
+                            <i class="fas fa-calendar-alt"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Youtube" aria-label="Youtube">
+                        <a class="has-text-white" target="_blank" href="https://youtube.com/kubernetescommunity">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+            <div class="column is-6">
+                <div class="has-text-centered">
+                <small class="has-text-white is-inline-block">© {{.Year}} The Kubernetes Authors | Documentation Distributed under <a href="https://git.k8s.io/website/LICENSE" class="has-text-white">CC BY 4.0</a></small>
+                </br>
+                <small class="has-text-white">Copyright © {{.Year}} The Linux Foundation ®. All
+                    rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of
+                    trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="has-text-white">Trademark Usage page</a></small>
+                <br>
+                <small class="has-text-white">ICP license: 京ICP备17074266号-3</small>
+                </div>
+            </div>
+            <div class="column is-3 has-text-right has-text-centered-mobile is-flex-sm justify-content-sm-end">
+                <ul class="is-inline is-marginless">
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="GitHub" aria-label="GitHub">
+                        <a class="has-text-white" target="_blank" href="https://github.com/kubernetes/kubernetes">
+                            <i class="fab fa-github"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Slack" aria-label="Slack">
+                        <a class="has-text-white" target="_blank" href="https://slack.k8s.io">
+                            <i class="fab fa-slack"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Contribute" aria-label="Contribute">
+                        <a class="has-text-white" target="_blank" href="https://git.k8s.io/community/contributors/guide">
+                            <i class="fas fa-edit"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Stack Overflow" aria-label="Stack Overflow">
+                        <a class="has-text-white" target="_blank" href="https://stackoverflow.com/questions/tagged/kubernetes">
+                            <i class="fab fa-stack-overflow"></i>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </footer>
 </body>
 
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-142101933-1"></script>

--- a/cmd/update-index/main.go
+++ b/cmd/update-index/main.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/blang/semver/v4"
@@ -255,12 +256,14 @@ func main() {
 		AllBins     []string
 		AllVersions []string
 		AllArch     []string
+		Year        int
 	}{
 		Binaries:    binaries,
 		AllOSes:     oses,
 		AllBins:     bins,
 		AllVersions: stableVersions[:numberOfVersions],
 		AllArch:     arch,
+		Year:        time.Now().Year(),
 	}); err != nil {
 		panic(err)
 	}

--- a/dist/index.html
+++ b/dist/index.html
@@ -5676,6 +5676,69 @@
             </tbody>
         </table>
     </section>
+    <footer class="footer has-background-primary">
+        <div class="columns">
+            <div class="column is-3 is-flex is-justify-content-center">
+                <ul class="is-inline is-marginless">
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="User mailing list" aria-label="User mailing list">
+                        <a class="has-text-white" target="_blank" href="https://discuss.kubernetes.io">
+                            <i class="fas fa-envelope"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Twitter" aria-label="Twitter">
+                        <a class="has-text-white" target="_blank" href="https://twitter.com/kubernetesio">
+                            <i class="fab fa-twitter"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Calendar" aria-label="Calendar">
+                        <a class="has-text-white" target="_blank" href="https://calendar.google.com/calendar/embed?src=calendar%40kubernetes.io">
+                            <i class="fas fa-calendar-alt"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Youtube" aria-label="Youtube">
+                        <a class="has-text-white" target="_blank" href="https://youtube.com/kubernetescommunity">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+            <div class="column is-6">
+                <div class="has-text-centered">
+                <small class="has-text-white is-inline-block">© 2023 The Kubernetes Authors | Documentation Distributed under <a href="https://git.k8s.io/website/LICENSE" class="has-text-white">CC BY 4.0</a></small>
+                </br>
+                <small class="has-text-white">Copyright © 2023 The Linux Foundation ®. All
+                    rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of
+                    trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="has-text-white">Trademark Usage page</a></small>
+                <br>
+                <small class="has-text-white">ICP license: 京ICP备17074266号-3</small>
+                </div>
+            </div>
+            <div class="column is-3 has-text-right has-text-centered-mobile is-flex-sm justify-content-sm-end">
+                <ul class="is-inline is-marginless">
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="GitHub" aria-label="GitHub">
+                        <a class="has-text-white" target="_blank" href="https://github.com/kubernetes/kubernetes">
+                            <i class="fab fa-github"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Slack" aria-label="Slack">
+                        <a class="has-text-white" target="_blank" href="https://slack.k8s.io">
+                            <i class="fab fa-slack"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Contribute" aria-label="Contribute">
+                        <a class="has-text-white" target="_blank" href="https://git.k8s.io/community/contributors/guide">
+                            <i class="fas fa-edit"></i>
+                        </a>
+                    </li>
+                    <li class="is-inline-block mx-2 is-size-3" data-tooltip="Stack Overflow" aria-label="Stack Overflow">
+                        <a class="has-text-white" target="_blank" href="https://stackoverflow.com/questions/tagged/kubernetes">
+                            <i class="fab fa-stack-overflow"></i>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </footer>
 </body>
 
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-142101933-1"></script>


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR adds a footer to the existing page that's in line with the main k8s docs footer.

##### Desktop
<img width="1266" alt="image" src="https://github.com/kubernetes-sigs/downloadkubernetes/assets/10358006/d4daf7b6-1425-41b5-b7b6-9b8b1e0556f3">

##### Mobile
<img width="184" alt="image" src="https://github.com/kubernetes-sigs/downloadkubernetes/assets/10358006/637d2cec-2144-4dd0-8764-780d099f73f5">
