### PR TITLE
Upgrade go to 1.20, dependabot config and github actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,30 @@
+---
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-  open-pull-requests-limit: 10
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
-  open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+    open-pull-requests-limit: 10

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -8,13 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: '1.17.x'
+          go-version: '1.20'
+          check-latest: true
 
       - name: Update index
         run: make update-index
@@ -23,11 +24,11 @@ jobs:
         id: create_pr
         run: |
           if [[ $(git diff --stat) != '' ]]; then
-            echo ::set-output name=create_pr::true
+            echo "create_pr=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3.11.0
+        uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v5.0.1
         if: ${{ steps.create_pr.outputs.create_pr == 'true' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,14 +8,12 @@ issues:
     - path: fake_.*\.go
       linters:
         - gocritic
-        - golint
         - dupl
 linters:
   disable-all: true
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -28,27 +26,23 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    - golint
     - gomodguard
     - goprintffuncname
     - gosimple
     - govet
     - ineffassign
-    - interfacer
-    - maligned
     - misspell
     - nakedret
     - prealloc
+    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 linters-settings:
   godox:

--- a/cmd/update-index/main.go
+++ b/cmd/update-index/main.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"regexp"
@@ -197,7 +197,7 @@ func main() {
 			fmt.Printf("%+v\n", err)
 			break
 		}
-		out, err := ioutil.ReadAll(reader)
+		out, err := io.ReadAll(reader)
 		if err != nil {
 			fmt.Printf("%+v\n", err)
 			break
@@ -268,7 +268,7 @@ func main() {
 		panic(err)
 	}
 
-	err = ioutil.WriteFile(args.outputFile, buf.Bytes(), os.FileMode(0o644)) // nolint: gocritic
+	err = os.WriteFile(args.outputFile, buf.Bytes(), os.FileMode(0o644)) // nolint: gocritic
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module sigs.k8s.io/downloadkubernetes
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/storage v1.30.1
 	github.com/blang/semver/v4 v4.0.0
 	google.golang.org/api v0.122.0
-	sigs.k8s.io/release-utils v0.7.3
+	sigs.k8s.io/release-utils v0.7.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
@@ -208,5 +208,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-sigs.k8s.io/release-utils v0.7.3 h1:6pS8x6c5RmdUgR9qcg1LO6hjUzuE4Yo9TGZ3DemrZdM=
-sigs.k8s.io/release-utils v0.7.3/go.mod h1:n0mVez/1PZYZaZUTJmxewxH3RJ/Lf7JUDh7TG1CASOE=
+sigs.k8s.io/release-utils v0.7.4 h1:17LmJrydpUloTCtaoWj95uKlcrUp4h2A9Sa+ZL+lV9w=
+sigs.k8s.io/release-utils v0.7.4/go.mod h1:JEt2QPHItd5Pg2UKLAU8PEaSlF4bUjCZimpxFDgymVU=

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.45.2
+VERSION=v1.52.2
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 


### PR DESCRIPTION
- upgrade to go1.20
- add github actions to dependabot config
- bump golangci-lint to v1.52.2
- update github action job


/hold

Need test-infra PR to update prow jobs
- [ ] https://github.com/kubernetes/test-infra/pull/29530

