### PR TITLE
update golangci-lint to v1.53.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.52.2
+VERSION=v1.53.3
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 


### PR DESCRIPTION
- update golangci-lint to v1.53.3
/assign @saschagrunert @xmudrii @palnabarun 
cc @kubernetes-sigs/release-engineering 