### PR TITLE
Enable and fix `err113`, `errorlint` and `forbidigo` lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,11 +25,14 @@ linters:
     - dupl
     - dupword
     - durationcheck
+    - err113
     - errcheck
     - errchkjson
     - errname
+    - errorlint
     - exhaustive
     - fatcontext
+    - forbidigo
     - forcetypeassert
     - gci
     - ginkgolinter
@@ -107,10 +110,7 @@ linters:
     - zerologlint
     # - cyclop
     # - depguard
-    # - err113
-    # - errorlint
     # - exhaustruct
-    # - forbidigo
     # - funlen
     # - lll
     # - mnd

--- a/cmd/update-index/main.go
+++ b/cmd/update-index/main.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"html/template"
@@ -39,6 +40,8 @@ const (
 	numberOfVersions = 4
 	baseURL          = release.ProductionBucketURL + "/release"
 )
+
+var errMajorVersion = errors.New("assuming that latest stable major version is 1")
 
 type Binary struct {
 	Version         string
@@ -163,7 +166,7 @@ func run() error {
 
 	err := fs.Parse(os.Args[1:])
 	if err != nil {
-		return fmt.Errorf("failed to parsing the flags: %v", err)
+		return fmt.Errorf("failed to parsing the flags: %w", err)
 	}
 
 	agent := http.NewAgent()
@@ -181,7 +184,7 @@ func run() error {
 	}
 
 	if latestStableSemver.Major != 1 {
-		return fmt.Errorf("assuming that latest stable major version is 1, but it's %d", latestStableSemver.Major)
+		return fmt.Errorf("%w, but it's %d", errMajorVersion, latestStableSemver.Major)
 	}
 
 	stableVersions := []string{string(latestStable)}


### PR DESCRIPTION
Fixing the linter reports.

cc @kubernetes-sigs/release-engineering 