### PR TITLE
fix verify-index errors

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,3 +20,5 @@ steps:
 substitutions:
   _BUCKET_NAME: random-bucket
   _FASTLY_SERVICE_NAME: dl.k8s.dev
+tags:
+  - downloadkubernetes

--- a/dist/index.html
+++ b/dist/index.html
@@ -68,10 +68,10 @@
                 <div>
                     <p class="heading">Stable Versions</p>
                     <div class="buttons has-addons is-centered" id="version">
+                        <span class="button" data-version="v1-36-0">v1.36.0</span>
                         <span class="button" data-version="v1-35-4">v1.35.4</span>
                         <span class="button" data-version="v1-34-7">v1.34.7</span>
                         <span class="button" data-version="v1-33-11">v1.33.11</span>
-                        <span class="button" data-version="v1-32-13">v1.32.13</span>
                     </div>
                 </div>
             </div>
@@ -88,6 +88,1260 @@
                     </tr>
                 </thead>
                 <tbody>
+                    <tr class="v1-36-0 darwin amd64 kubectl">
+                        <td>v1.36.0</td>
+                        <td>darwin</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl">kubectl</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl">dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 darwin amd64 kubectl-convert">
+                        <td>v1.36.0</td>
+                        <td>darwin</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl-convert">kubectl-convert</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl-convert">dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl-convert</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/amd64/kubectl-convert.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 darwin arm64 kubectl">
+                        <td>v1.36.0</td>
+                        <td>darwin</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl">kubectl</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl">dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 darwin arm64 kubectl-convert">
+                        <td>v1.36.0</td>
+                        <td>darwin</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl-convert">kubectl-convert</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl-convert">dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl-convert</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/darwin/arm64/kubectl-convert.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux a-386 kubectl">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>386</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/386/kubectl">kubectl</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/386/kubectl">dl.k8s.io/v1.36.0/bin/linux/386/kubectl</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/386/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/386/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/386/kubectl.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux a-386 kubectl-convert">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>386</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/386/kubectl-convert">kubectl-convert</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/386/kubectl-convert">dl.k8s.io/v1.36.0/bin/linux/386/kubectl-convert</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/386/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/386/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/386/kubectl-convert.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 apiextensions-apiserver">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/apiextensions-apiserver">apiextensions-apiserver</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/apiextensions-apiserver">dl.k8s.io/v1.36.0/bin/linux/amd64/apiextensions-apiserver</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/apiextensions-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/apiextensions-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/apiextensions-apiserver.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 kube-aggregator">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-aggregator">kube-aggregator</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-aggregator">dl.k8s.io/v1.36.0/bin/linux/amd64/kube-aggregator</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-aggregator.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-aggregator.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-aggregator.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 kube-apiserver">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-apiserver">kube-apiserver</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-apiserver">dl.k8s.io/v1.36.0/bin/linux/amd64/kube-apiserver</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-apiserver.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 kube-controller-manager">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-controller-manager">kube-controller-manager</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-controller-manager">dl.k8s.io/v1.36.0/bin/linux/amd64/kube-controller-manager</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-controller-manager.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-controller-manager.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-controller-manager.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 kube-log-runner">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-log-runner">kube-log-runner</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-log-runner">dl.k8s.io/v1.36.0/bin/linux/amd64/kube-log-runner</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-log-runner.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-log-runner.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-log-runner.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 kube-proxy">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-proxy">kube-proxy</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-proxy">dl.k8s.io/v1.36.0/bin/linux/amd64/kube-proxy</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-proxy.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-proxy.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-proxy.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 kube-scheduler">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-scheduler">kube-scheduler</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-scheduler">dl.k8s.io/v1.36.0/bin/linux/amd64/kube-scheduler</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-scheduler.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-scheduler.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kube-scheduler.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 kubeadm">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubeadm">kubeadm</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubeadm">dl.k8s.io/v1.36.0/bin/linux/amd64/kubeadm</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubeadm.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubeadm.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubeadm.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 kubectl">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl">kubectl</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl">dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 kubectl-convert">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl-convert">kubectl-convert</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl-convert">dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl-convert</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubectl-convert.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 kubelet">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubelet">kubelet</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubelet">dl.k8s.io/v1.36.0/bin/linux/amd64/kubelet</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubelet.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubelet.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/kubelet.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux amd64 mounter">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/mounter">mounter</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/mounter">dl.k8s.io/v1.36.0/bin/linux/amd64/mounter</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/mounter.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/mounter.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/amd64/mounter.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm kubectl">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm/kubectl">kubectl</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm/kubectl">dl.k8s.io/v1.36.0/bin/linux/arm/kubectl</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm/kubectl.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm kubectl-convert">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm/kubectl-convert">kubectl-convert</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm/kubectl-convert">dl.k8s.io/v1.36.0/bin/linux/arm/kubectl-convert</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm/kubectl-convert.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 apiextensions-apiserver">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/apiextensions-apiserver">apiextensions-apiserver</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/apiextensions-apiserver">dl.k8s.io/v1.36.0/bin/linux/arm64/apiextensions-apiserver</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/apiextensions-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/apiextensions-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/apiextensions-apiserver.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 kube-aggregator">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-aggregator">kube-aggregator</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-aggregator">dl.k8s.io/v1.36.0/bin/linux/arm64/kube-aggregator</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-aggregator.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-aggregator.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-aggregator.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 kube-apiserver">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-apiserver">kube-apiserver</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-apiserver">dl.k8s.io/v1.36.0/bin/linux/arm64/kube-apiserver</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-apiserver.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 kube-controller-manager">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-controller-manager">kube-controller-manager</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-controller-manager">dl.k8s.io/v1.36.0/bin/linux/arm64/kube-controller-manager</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-controller-manager.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-controller-manager.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-controller-manager.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 kube-log-runner">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-log-runner">kube-log-runner</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-log-runner">dl.k8s.io/v1.36.0/bin/linux/arm64/kube-log-runner</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-log-runner.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-log-runner.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-log-runner.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 kube-proxy">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-proxy">kube-proxy</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-proxy">dl.k8s.io/v1.36.0/bin/linux/arm64/kube-proxy</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-proxy.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-proxy.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-proxy.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 kube-scheduler">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-scheduler">kube-scheduler</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-scheduler">dl.k8s.io/v1.36.0/bin/linux/arm64/kube-scheduler</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-scheduler.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-scheduler.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kube-scheduler.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 kubeadm">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubeadm">kubeadm</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubeadm">dl.k8s.io/v1.36.0/bin/linux/arm64/kubeadm</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubeadm.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubeadm.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubeadm.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 kubectl">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl">kubectl</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl">dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 kubectl-convert">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl-convert">kubectl-convert</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl-convert">dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl-convert</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubectl-convert.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 kubelet">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubelet">kubelet</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubelet">dl.k8s.io/v1.36.0/bin/linux/arm64/kubelet</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubelet.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubelet.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/kubelet.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux arm64 mounter">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/mounter">mounter</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/mounter">dl.k8s.io/v1.36.0/bin/linux/arm64/mounter</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/mounter.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/mounter.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/arm64/mounter.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le apiextensions-apiserver">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/apiextensions-apiserver">apiextensions-apiserver</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/apiextensions-apiserver">dl.k8s.io/v1.36.0/bin/linux/ppc64le/apiextensions-apiserver</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/apiextensions-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/apiextensions-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/apiextensions-apiserver.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le kube-aggregator">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-aggregator">kube-aggregator</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-aggregator">dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-aggregator</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-aggregator.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-aggregator.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-aggregator.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le kube-apiserver">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-apiserver">kube-apiserver</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-apiserver">dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-apiserver</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-apiserver.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le kube-controller-manager">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-controller-manager">kube-controller-manager</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-controller-manager">dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-controller-manager</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-controller-manager.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-controller-manager.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-controller-manager.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le kube-log-runner">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-log-runner">kube-log-runner</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-log-runner">dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-log-runner</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-log-runner.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-log-runner.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-log-runner.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le kube-proxy">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-proxy">kube-proxy</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-proxy">dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-proxy</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-proxy.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-proxy.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-proxy.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le kube-scheduler">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-scheduler">kube-scheduler</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-scheduler">dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-scheduler</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-scheduler.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-scheduler.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kube-scheduler.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le kubeadm">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubeadm">kubeadm</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubeadm">dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubeadm</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubeadm.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubeadm.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubeadm.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le kubectl">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl">kubectl</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl">dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le kubectl-convert">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl-convert">kubectl-convert</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl-convert">dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl-convert</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubectl-convert.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le kubelet">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubelet">kubelet</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubelet">dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubelet</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubelet.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubelet.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/kubelet.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux ppc64le mounter">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>ppc64le</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/mounter">mounter</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/mounter">dl.k8s.io/v1.36.0/bin/linux/ppc64le/mounter</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/mounter.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/mounter.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/ppc64le/mounter.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x apiextensions-apiserver">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/apiextensions-apiserver">apiextensions-apiserver</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/apiextensions-apiserver">dl.k8s.io/v1.36.0/bin/linux/s390x/apiextensions-apiserver</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/apiextensions-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/apiextensions-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/apiextensions-apiserver.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x kube-aggregator">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-aggregator">kube-aggregator</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-aggregator">dl.k8s.io/v1.36.0/bin/linux/s390x/kube-aggregator</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-aggregator.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-aggregator.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-aggregator.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x kube-apiserver">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-apiserver">kube-apiserver</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-apiserver">dl.k8s.io/v1.36.0/bin/linux/s390x/kube-apiserver</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-apiserver.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x kube-controller-manager">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-controller-manager">kube-controller-manager</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-controller-manager">dl.k8s.io/v1.36.0/bin/linux/s390x/kube-controller-manager</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-controller-manager.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-controller-manager.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-controller-manager.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x kube-log-runner">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-log-runner">kube-log-runner</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-log-runner">dl.k8s.io/v1.36.0/bin/linux/s390x/kube-log-runner</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-log-runner.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-log-runner.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-log-runner.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x kube-proxy">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-proxy">kube-proxy</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-proxy">dl.k8s.io/v1.36.0/bin/linux/s390x/kube-proxy</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-proxy.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-proxy.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-proxy.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x kube-scheduler">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-scheduler">kube-scheduler</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-scheduler">dl.k8s.io/v1.36.0/bin/linux/s390x/kube-scheduler</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-scheduler.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-scheduler.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kube-scheduler.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x kubeadm">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubeadm">kubeadm</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubeadm">dl.k8s.io/v1.36.0/bin/linux/s390x/kubeadm</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubeadm.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubeadm.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubeadm.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x kubectl">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl">kubectl</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl">dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x kubectl-convert">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl-convert">kubectl-convert</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl-convert">dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl-convert</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubectl-convert.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x kubelet">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubelet">kubelet</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubelet">dl.k8s.io/v1.36.0/bin/linux/s390x/kubelet</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubelet.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubelet.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/kubelet.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 linux s390x mounter">
+                        <td>v1.36.0</td>
+                        <td>linux</td>
+                        <td>s390x</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/mounter">mounter</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/mounter">dl.k8s.io/v1.36.0/bin/linux/s390x/mounter</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/mounter.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/mounter.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/linux/s390x/mounter.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 windows a-386 kubectl-convert.exe">
+                        <td>v1.36.0</td>
+                        <td>windows</td>
+                        <td>386</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/windows/386/kubectl-convert.exe">kubectl-convert.exe</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/386/kubectl-convert.exe">dl.k8s.io/v1.36.0/bin/windows/386/kubectl-convert.exe</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/386/kubectl-convert.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/386/kubectl-convert.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/386/kubectl-convert.exe.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 windows a-386 kubectl.exe">
+                        <td>v1.36.0</td>
+                        <td>windows</td>
+                        <td>386</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/windows/386/kubectl.exe">kubectl.exe</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/386/kubectl.exe">dl.k8s.io/v1.36.0/bin/windows/386/kubectl.exe</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/386/kubectl.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/386/kubectl.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/386/kubectl.exe.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 windows amd64 kube-log-runner.exe">
+                        <td>v1.36.0</td>
+                        <td>windows</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kube-log-runner.exe">kube-log-runner.exe</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kube-log-runner.exe">dl.k8s.io/v1.36.0/bin/windows/amd64/kube-log-runner.exe</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kube-log-runner.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kube-log-runner.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kube-log-runner.exe.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 windows amd64 kube-proxy.exe">
+                        <td>v1.36.0</td>
+                        <td>windows</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kube-proxy.exe">kube-proxy.exe</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kube-proxy.exe">dl.k8s.io/v1.36.0/bin/windows/amd64/kube-proxy.exe</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kube-proxy.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kube-proxy.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kube-proxy.exe.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 windows amd64 kubeadm.exe">
+                        <td>v1.36.0</td>
+                        <td>windows</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubeadm.exe">kubeadm.exe</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubeadm.exe">dl.k8s.io/v1.36.0/bin/windows/amd64/kubeadm.exe</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubeadm.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubeadm.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubeadm.exe.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 windows amd64 kubectl-convert.exe">
+                        <td>v1.36.0</td>
+                        <td>windows</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl-convert.exe">kubectl-convert.exe</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl-convert.exe">dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl-convert.exe</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl-convert.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl-convert.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl-convert.exe.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 windows amd64 kubectl.exe">
+                        <td>v1.36.0</td>
+                        <td>windows</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl.exe">kubectl.exe</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl.exe">dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl.exe</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubectl.exe.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 windows amd64 kubelet.exe">
+                        <td>v1.36.0</td>
+                        <td>windows</td>
+                        <td>amd64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubelet.exe">kubelet.exe</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubelet.exe">dl.k8s.io/v1.36.0/bin/windows/amd64/kubelet.exe</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubelet.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubelet.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/amd64/kubelet.exe.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 windows arm64 kubectl-convert.exe">
+                        <td>v1.36.0</td>
+                        <td>windows</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl-convert.exe">kubectl-convert.exe</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl-convert.exe">dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl-convert.exe</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl-convert.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl-convert.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl-convert.exe.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="v1-36-0 windows arm64 kubectl.exe">
+                        <td>v1.36.0</td>
+                        <td>windows</td>
+                        <td>arm64</td>
+                        <td>
+                            <span title="download">
+                                <a href="https://dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl.exe">kubectl.exe</a>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="icon">
+                                <i class="fa fa-copy"></i>
+                            </span>
+                            <span title="copy to clipboard">
+                                <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl.exe">dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl.exe</a>
+                                (<a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.36.0/bin/windows/arm64/kubectl.exe.cert">certificate</a>)
+                            </span>
+                        </td>
+                    </tr>
                     <tr class="v1-35-4 darwin amd64 kubectl">
                         <td>v1.35.4</td>
                         <td>darwin</td>
@@ -3847,1260 +5101,6 @@
                             <span title="copy to clipboard">
                                 <a class="copy" href="https://dl.k8s.io/v1.33.11/bin/windows/arm64/kubectl.exe">dl.k8s.io/v1.33.11/bin/windows/arm64/kubectl.exe</a>
                                 (<a class="copy" href="https://dl.k8s.io/v1.33.11/bin/windows/arm64/kubectl.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.33.11/bin/windows/arm64/kubectl.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.33.11/bin/windows/arm64/kubectl.exe.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 darwin amd64 kubectl">
-                        <td>v1.32.13</td>
-                        <td>darwin</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl">kubectl</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl">dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 darwin amd64 kubectl-convert">
-                        <td>v1.32.13</td>
-                        <td>darwin</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl-convert">kubectl-convert</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl-convert">dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl-convert</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/amd64/kubectl-convert.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 darwin arm64 kubectl">
-                        <td>v1.32.13</td>
-                        <td>darwin</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl">kubectl</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl">dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 darwin arm64 kubectl-convert">
-                        <td>v1.32.13</td>
-                        <td>darwin</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl-convert">kubectl-convert</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl-convert">dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl-convert</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/darwin/arm64/kubectl-convert.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux a-386 kubectl">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>386</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/386/kubectl">kubectl</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/386/kubectl">dl.k8s.io/v1.32.13/bin/linux/386/kubectl</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/386/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/386/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/386/kubectl.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux a-386 kubectl-convert">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>386</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/386/kubectl-convert">kubectl-convert</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/386/kubectl-convert">dl.k8s.io/v1.32.13/bin/linux/386/kubectl-convert</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/386/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/386/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/386/kubectl-convert.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 apiextensions-apiserver">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/apiextensions-apiserver">apiextensions-apiserver</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/apiextensions-apiserver">dl.k8s.io/v1.32.13/bin/linux/amd64/apiextensions-apiserver</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/apiextensions-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/apiextensions-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/apiextensions-apiserver.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 kube-aggregator">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-aggregator">kube-aggregator</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-aggregator">dl.k8s.io/v1.32.13/bin/linux/amd64/kube-aggregator</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-aggregator.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-aggregator.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-aggregator.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 kube-apiserver">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-apiserver">kube-apiserver</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-apiserver">dl.k8s.io/v1.32.13/bin/linux/amd64/kube-apiserver</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-apiserver.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 kube-controller-manager">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-controller-manager">kube-controller-manager</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-controller-manager">dl.k8s.io/v1.32.13/bin/linux/amd64/kube-controller-manager</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-controller-manager.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-controller-manager.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-controller-manager.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 kube-log-runner">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-log-runner">kube-log-runner</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-log-runner">dl.k8s.io/v1.32.13/bin/linux/amd64/kube-log-runner</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-log-runner.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-log-runner.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-log-runner.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 kube-proxy">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-proxy">kube-proxy</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-proxy">dl.k8s.io/v1.32.13/bin/linux/amd64/kube-proxy</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-proxy.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-proxy.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-proxy.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 kube-scheduler">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-scheduler">kube-scheduler</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-scheduler">dl.k8s.io/v1.32.13/bin/linux/amd64/kube-scheduler</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-scheduler.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-scheduler.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kube-scheduler.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 kubeadm">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubeadm">kubeadm</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubeadm">dl.k8s.io/v1.32.13/bin/linux/amd64/kubeadm</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubeadm.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubeadm.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubeadm.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 kubectl">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl">kubectl</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl">dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 kubectl-convert">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl-convert">kubectl-convert</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl-convert">dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl-convert</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubectl-convert.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 kubelet">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubelet">kubelet</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubelet">dl.k8s.io/v1.32.13/bin/linux/amd64/kubelet</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubelet.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubelet.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/kubelet.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux amd64 mounter">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/mounter">mounter</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/mounter">dl.k8s.io/v1.32.13/bin/linux/amd64/mounter</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/mounter.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/mounter.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/amd64/mounter.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm kubectl">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm/kubectl">kubectl</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm/kubectl">dl.k8s.io/v1.32.13/bin/linux/arm/kubectl</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm/kubectl.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm kubectl-convert">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm/kubectl-convert">kubectl-convert</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm/kubectl-convert">dl.k8s.io/v1.32.13/bin/linux/arm/kubectl-convert</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm/kubectl-convert.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 apiextensions-apiserver">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/apiextensions-apiserver">apiextensions-apiserver</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/apiextensions-apiserver">dl.k8s.io/v1.32.13/bin/linux/arm64/apiextensions-apiserver</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/apiextensions-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/apiextensions-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/apiextensions-apiserver.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 kube-aggregator">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-aggregator">kube-aggregator</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-aggregator">dl.k8s.io/v1.32.13/bin/linux/arm64/kube-aggregator</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-aggregator.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-aggregator.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-aggregator.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 kube-apiserver">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-apiserver">kube-apiserver</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-apiserver">dl.k8s.io/v1.32.13/bin/linux/arm64/kube-apiserver</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-apiserver.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 kube-controller-manager">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-controller-manager">kube-controller-manager</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-controller-manager">dl.k8s.io/v1.32.13/bin/linux/arm64/kube-controller-manager</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-controller-manager.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-controller-manager.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-controller-manager.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 kube-log-runner">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-log-runner">kube-log-runner</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-log-runner">dl.k8s.io/v1.32.13/bin/linux/arm64/kube-log-runner</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-log-runner.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-log-runner.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-log-runner.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 kube-proxy">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-proxy">kube-proxy</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-proxy">dl.k8s.io/v1.32.13/bin/linux/arm64/kube-proxy</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-proxy.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-proxy.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-proxy.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 kube-scheduler">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-scheduler">kube-scheduler</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-scheduler">dl.k8s.io/v1.32.13/bin/linux/arm64/kube-scheduler</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-scheduler.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-scheduler.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kube-scheduler.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 kubeadm">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubeadm">kubeadm</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubeadm">dl.k8s.io/v1.32.13/bin/linux/arm64/kubeadm</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubeadm.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubeadm.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubeadm.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 kubectl">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl">kubectl</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl">dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 kubectl-convert">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl-convert">kubectl-convert</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl-convert">dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl-convert</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubectl-convert.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 kubelet">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubelet">kubelet</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubelet">dl.k8s.io/v1.32.13/bin/linux/arm64/kubelet</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubelet.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubelet.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/kubelet.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux arm64 mounter">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/mounter">mounter</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/mounter">dl.k8s.io/v1.32.13/bin/linux/arm64/mounter</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/mounter.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/mounter.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/arm64/mounter.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le apiextensions-apiserver">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/apiextensions-apiserver">apiextensions-apiserver</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/apiextensions-apiserver">dl.k8s.io/v1.32.13/bin/linux/ppc64le/apiextensions-apiserver</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/apiextensions-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/apiextensions-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/apiextensions-apiserver.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le kube-aggregator">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-aggregator">kube-aggregator</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-aggregator">dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-aggregator</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-aggregator.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-aggregator.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-aggregator.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le kube-apiserver">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-apiserver">kube-apiserver</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-apiserver">dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-apiserver</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-apiserver.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le kube-controller-manager">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-controller-manager">kube-controller-manager</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-controller-manager">dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-controller-manager</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-controller-manager.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-controller-manager.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-controller-manager.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le kube-log-runner">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-log-runner">kube-log-runner</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-log-runner">dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-log-runner</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-log-runner.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-log-runner.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-log-runner.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le kube-proxy">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-proxy">kube-proxy</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-proxy">dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-proxy</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-proxy.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-proxy.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-proxy.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le kube-scheduler">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-scheduler">kube-scheduler</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-scheduler">dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-scheduler</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-scheduler.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-scheduler.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kube-scheduler.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le kubeadm">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubeadm">kubeadm</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubeadm">dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubeadm</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubeadm.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubeadm.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubeadm.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le kubectl">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl">kubectl</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl">dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le kubectl-convert">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl-convert">kubectl-convert</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl-convert">dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl-convert</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubectl-convert.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le kubelet">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubelet">kubelet</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubelet">dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubelet</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubelet.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubelet.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/kubelet.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux ppc64le mounter">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>ppc64le</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/mounter">mounter</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/mounter">dl.k8s.io/v1.32.13/bin/linux/ppc64le/mounter</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/mounter.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/mounter.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/ppc64le/mounter.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x apiextensions-apiserver">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/apiextensions-apiserver">apiextensions-apiserver</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/apiextensions-apiserver">dl.k8s.io/v1.32.13/bin/linux/s390x/apiextensions-apiserver</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/apiextensions-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/apiextensions-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/apiextensions-apiserver.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x kube-aggregator">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-aggregator">kube-aggregator</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-aggregator">dl.k8s.io/v1.32.13/bin/linux/s390x/kube-aggregator</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-aggregator.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-aggregator.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-aggregator.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x kube-apiserver">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-apiserver">kube-apiserver</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-apiserver">dl.k8s.io/v1.32.13/bin/linux/s390x/kube-apiserver</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-apiserver.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-apiserver.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-apiserver.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x kube-controller-manager">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-controller-manager">kube-controller-manager</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-controller-manager">dl.k8s.io/v1.32.13/bin/linux/s390x/kube-controller-manager</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-controller-manager.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-controller-manager.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-controller-manager.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x kube-log-runner">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-log-runner">kube-log-runner</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-log-runner">dl.k8s.io/v1.32.13/bin/linux/s390x/kube-log-runner</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-log-runner.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-log-runner.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-log-runner.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x kube-proxy">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-proxy">kube-proxy</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-proxy">dl.k8s.io/v1.32.13/bin/linux/s390x/kube-proxy</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-proxy.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-proxy.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-proxy.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x kube-scheduler">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-scheduler">kube-scheduler</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-scheduler">dl.k8s.io/v1.32.13/bin/linux/s390x/kube-scheduler</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-scheduler.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-scheduler.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kube-scheduler.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x kubeadm">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubeadm">kubeadm</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubeadm">dl.k8s.io/v1.32.13/bin/linux/s390x/kubeadm</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubeadm.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubeadm.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubeadm.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x kubectl">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl">kubectl</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl">dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x kubectl-convert">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl-convert">kubectl-convert</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl-convert">dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl-convert</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl-convert.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl-convert.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubectl-convert.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x kubelet">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubelet">kubelet</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubelet">dl.k8s.io/v1.32.13/bin/linux/s390x/kubelet</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubelet.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubelet.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/kubelet.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 linux s390x mounter">
-                        <td>v1.32.13</td>
-                        <td>linux</td>
-                        <td>s390x</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/mounter">mounter</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/mounter">dl.k8s.io/v1.32.13/bin/linux/s390x/mounter</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/mounter.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/mounter.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/linux/s390x/mounter.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 windows a-386 kubectl-convert.exe">
-                        <td>v1.32.13</td>
-                        <td>windows</td>
-                        <td>386</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/windows/386/kubectl-convert.exe">kubectl-convert.exe</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/386/kubectl-convert.exe">dl.k8s.io/v1.32.13/bin/windows/386/kubectl-convert.exe</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/386/kubectl-convert.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/386/kubectl-convert.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/386/kubectl-convert.exe.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 windows a-386 kubectl.exe">
-                        <td>v1.32.13</td>
-                        <td>windows</td>
-                        <td>386</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/windows/386/kubectl.exe">kubectl.exe</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/386/kubectl.exe">dl.k8s.io/v1.32.13/bin/windows/386/kubectl.exe</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/386/kubectl.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/386/kubectl.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/386/kubectl.exe.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 windows amd64 kube-log-runner.exe">
-                        <td>v1.32.13</td>
-                        <td>windows</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kube-log-runner.exe">kube-log-runner.exe</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kube-log-runner.exe">dl.k8s.io/v1.32.13/bin/windows/amd64/kube-log-runner.exe</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kube-log-runner.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kube-log-runner.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kube-log-runner.exe.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 windows amd64 kube-proxy.exe">
-                        <td>v1.32.13</td>
-                        <td>windows</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kube-proxy.exe">kube-proxy.exe</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kube-proxy.exe">dl.k8s.io/v1.32.13/bin/windows/amd64/kube-proxy.exe</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kube-proxy.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kube-proxy.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kube-proxy.exe.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 windows amd64 kubeadm.exe">
-                        <td>v1.32.13</td>
-                        <td>windows</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubeadm.exe">kubeadm.exe</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubeadm.exe">dl.k8s.io/v1.32.13/bin/windows/amd64/kubeadm.exe</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubeadm.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubeadm.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubeadm.exe.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 windows amd64 kubectl-convert.exe">
-                        <td>v1.32.13</td>
-                        <td>windows</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl-convert.exe">kubectl-convert.exe</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl-convert.exe">dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl-convert.exe</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl-convert.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl-convert.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl-convert.exe.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 windows amd64 kubectl.exe">
-                        <td>v1.32.13</td>
-                        <td>windows</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl.exe">kubectl.exe</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl.exe">dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl.exe</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubectl.exe.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 windows amd64 kubelet.exe">
-                        <td>v1.32.13</td>
-                        <td>windows</td>
-                        <td>amd64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubelet.exe">kubelet.exe</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubelet.exe">dl.k8s.io/v1.32.13/bin/windows/amd64/kubelet.exe</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubelet.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubelet.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/amd64/kubelet.exe.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 windows arm64 kubectl-convert.exe">
-                        <td>v1.32.13</td>
-                        <td>windows</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl-convert.exe">kubectl-convert.exe</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl-convert.exe">dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl-convert.exe</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl-convert.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl-convert.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl-convert.exe.cert">certificate</a>)
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="v1-32-13 windows arm64 kubectl.exe">
-                        <td>v1.32.13</td>
-                        <td>windows</td>
-                        <td>arm64</td>
-                        <td>
-                            <span title="download">
-                                <a href="https://dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl.exe">kubectl.exe</a>
-                            </span>
-                        </td>
-                        <td>
-                            <span class="icon">
-                                <i class="fa fa-copy"></i>
-                            </span>
-                            <span title="copy to clipboard">
-                                <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl.exe">dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl.exe</a>
-                                (<a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl.exe.sha256">checksum</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl.exe.sig">signature</a> | <a class="copy" href="https://dl.k8s.io/v1.32.13/bin/windows/arm64/kubectl.exe.cert">certificate</a>)
                             </span>
                         </td>
                     </tr>

--- a/dist/release_binaries.json
+++ b/dist/release_binaries.json
@@ -1,6 +1,402 @@
 {
   "Binaries": [
     {
+      "Version": "v1.36.0",
+      "OperatingSystem": "darwin",
+      "Architecture": "amd64",
+      "Name": "kubectl"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "darwin",
+      "Architecture": "amd64",
+      "Name": "kubectl-convert"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "darwin",
+      "Architecture": "arm64",
+      "Name": "kubectl"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "darwin",
+      "Architecture": "arm64",
+      "Name": "kubectl-convert"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "386",
+      "Name": "kubectl"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "386",
+      "Name": "kubectl-convert"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "apiextensions-apiserver"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "kube-aggregator"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "kube-apiserver"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "kube-controller-manager"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "kube-log-runner"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "kube-proxy"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "kube-scheduler"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "kubeadm"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "kubectl"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "kubectl-convert"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "kubelet"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "amd64",
+      "Name": "mounter"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm",
+      "Name": "kubectl"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm",
+      "Name": "kubectl-convert"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "apiextensions-apiserver"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "kube-aggregator"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "kube-apiserver"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "kube-controller-manager"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "kube-log-runner"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "kube-proxy"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "kube-scheduler"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "kubeadm"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "kubectl"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "kubectl-convert"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "kubelet"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "arm64",
+      "Name": "mounter"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "apiextensions-apiserver"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "kube-aggregator"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "kube-apiserver"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "kube-controller-manager"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "kube-log-runner"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "kube-proxy"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "kube-scheduler"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "kubeadm"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "kubectl"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "kubectl-convert"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "kubelet"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "ppc64le",
+      "Name": "mounter"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "apiextensions-apiserver"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "kube-aggregator"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "kube-apiserver"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "kube-controller-manager"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "kube-log-runner"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "kube-proxy"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "kube-scheduler"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "kubeadm"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "kubectl"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "kubectl-convert"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "kubelet"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "linux",
+      "Architecture": "s390x",
+      "Name": "mounter"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "windows",
+      "Architecture": "386",
+      "Name": "kubectl-convert.exe"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "windows",
+      "Architecture": "386",
+      "Name": "kubectl.exe"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "windows",
+      "Architecture": "amd64",
+      "Name": "kube-log-runner.exe"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "windows",
+      "Architecture": "amd64",
+      "Name": "kube-proxy.exe"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "windows",
+      "Architecture": "amd64",
+      "Name": "kubeadm.exe"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "windows",
+      "Architecture": "amd64",
+      "Name": "kubectl-convert.exe"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "windows",
+      "Architecture": "amd64",
+      "Name": "kubectl.exe"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "windows",
+      "Architecture": "amd64",
+      "Name": "kubelet.exe"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "windows",
+      "Architecture": "arm64",
+      "Name": "kubectl-convert.exe"
+    },
+    {
+      "Version": "v1.36.0",
+      "OperatingSystem": "windows",
+      "Architecture": "arm64",
+      "Name": "kubectl.exe"
+    },
+    {
       "Version": "v1.35.4",
       "OperatingSystem": "darwin",
       "Architecture": "amd64",
@@ -1184,402 +1580,6 @@
     },
     {
       "Version": "v1.33.11",
-      "OperatingSystem": "windows",
-      "Architecture": "arm64",
-      "Name": "kubectl.exe"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "darwin",
-      "Architecture": "amd64",
-      "Name": "kubectl"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "darwin",
-      "Architecture": "amd64",
-      "Name": "kubectl-convert"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "darwin",
-      "Architecture": "arm64",
-      "Name": "kubectl"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "darwin",
-      "Architecture": "arm64",
-      "Name": "kubectl-convert"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "386",
-      "Name": "kubectl"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "386",
-      "Name": "kubectl-convert"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "apiextensions-apiserver"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "kube-aggregator"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "kube-apiserver"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "kube-controller-manager"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "kube-log-runner"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "kube-proxy"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "kube-scheduler"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "kubeadm"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "kubectl"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "kubectl-convert"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "kubelet"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "amd64",
-      "Name": "mounter"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm",
-      "Name": "kubectl"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm",
-      "Name": "kubectl-convert"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "apiextensions-apiserver"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "kube-aggregator"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "kube-apiserver"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "kube-controller-manager"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "kube-log-runner"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "kube-proxy"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "kube-scheduler"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "kubeadm"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "kubectl"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "kubectl-convert"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "kubelet"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "arm64",
-      "Name": "mounter"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "apiextensions-apiserver"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "kube-aggregator"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "kube-apiserver"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "kube-controller-manager"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "kube-log-runner"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "kube-proxy"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "kube-scheduler"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "kubeadm"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "kubectl"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "kubectl-convert"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "kubelet"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "ppc64le",
-      "Name": "mounter"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "apiextensions-apiserver"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "kube-aggregator"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "kube-apiserver"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "kube-controller-manager"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "kube-log-runner"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "kube-proxy"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "kube-scheduler"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "kubeadm"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "kubectl"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "kubectl-convert"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "kubelet"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "linux",
-      "Architecture": "s390x",
-      "Name": "mounter"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "windows",
-      "Architecture": "386",
-      "Name": "kubectl-convert.exe"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "windows",
-      "Architecture": "386",
-      "Name": "kubectl.exe"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "windows",
-      "Architecture": "amd64",
-      "Name": "kube-log-runner.exe"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "windows",
-      "Architecture": "amd64",
-      "Name": "kube-proxy.exe"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "windows",
-      "Architecture": "amd64",
-      "Name": "kubeadm.exe"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "windows",
-      "Architecture": "amd64",
-      "Name": "kubectl-convert.exe"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "windows",
-      "Architecture": "amd64",
-      "Name": "kubectl.exe"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "windows",
-      "Architecture": "amd64",
-      "Name": "kubelet.exe"
-    },
-    {
-      "Version": "v1.32.13",
-      "OperatingSystem": "windows",
-      "Architecture": "arm64",
-      "Name": "kubectl-convert.exe"
-    },
-    {
-      "Version": "v1.32.13",
       "OperatingSystem": "windows",
       "Architecture": "arm64",
       "Name": "kubectl.exe"
@@ -1591,10 +1591,10 @@
     "windows"
   ],
   "AllVersions": [
+    "v1.36.0",
     "v1.35.4",
     "v1.34.7",
-    "v1.33.11",
-    "v1.32.13"
+    "v1.33.11"
   ],
   "AllArch": [
     "386",

--- a/scripts/upload-to-gcs.sh
+++ b/scripts/upload-to-gcs.sh
@@ -21,10 +21,10 @@ set -o pipefail
 rm -rf dist/index.html
 gcloud storage cp gs://${BUCKET_NAME}/index.html dist/index.html
 
-make verify-index
-VERIFY_EXIT_CODE=$?
-if [ $VERIFY_EXIT_CODE -ne 1 ]; then
-  exit $VERIFY_EXIT_CODE
+VERIFY_EXIT_CODE=0
+make verify-index || VERIFY_EXIT_CODE=$?
+if [ "$VERIFY_EXIT_CODE" -eq 0 ]; then
+  exit 0
 fi
 
 ## We run this code block if we detect that a new version has been released
@@ -41,7 +41,7 @@ npm install
 npm run build-prod
 
 # https://www.fastly.com/documentation/guides/full-site-delivery/purging/working-with-surrogate-keys/
-gcloud storage cp dist/ gs://${BUCKET_NAME}/ --recursive \
+gcloud storage cp dist/* gs://${BUCKET_NAME}/ --recursive \
   --custom-metadata="Surrogate-Key=downloadkubernetes" \
   --custom-metadata="Surrogate-Control=max-age=86400"
 


### PR DESCRIPTION
downloadkubernetes's dl.k8s.io deploymennt was broken because of a bug.

This has been fixed now. https://dl.k8s.io/ is showing the latest releases.